### PR TITLE
feat(legal): Affiliate-Kennzeichnung auf Produktseiten

### DIFF
--- a/app/produkte/[slug]/page.tsx
+++ b/app/produkte/[slug]/page.tsx
@@ -239,7 +239,7 @@ export default async function ProductPage({ params }: ProductPageProps) {
                       variant="button"
                       className="w-full justify-center"
                     >
-                      Jetzt kaufen bei Amazon
+                      Jetzt kaufen bei Amazon*
                     </AffiliateLink>
                   </div>
 
@@ -364,8 +364,11 @@ export default async function ProductPage({ params }: ProductPageProps) {
                       variant="button"
                       className="w-full justify-center bg-cognac-600 hover:bg-cognac-500"
                     >
-                      Bei Amazon kaufen
+                      Bei Amazon kaufen*
                     </AffiliateLink>
+                    <p className="text-xs text-creme-100/60 mt-3">
+                      * Affiliate-Link — für Sie entstehen keine Mehrkosten.
+                    </p>
                   </div>
                 </div>
               </aside>


### PR DESCRIPTION
## Summary
- Sternchen (*) bei CTA-Buttons auf Produktseiten hinzugefügt ("Jetzt kaufen bei Amazon*", "Bei Amazon kaufen*")
- Affiliate-Disclosure-Hinweis in der Sidebar-Kaufbox ergänzt
- Impressum hat bereits vollständigen Affiliate-Hinweis (kein Änderungsbedarf)
- Geschenkideen-Seiten haben keine direkten Affiliate-Links (nur interne Produktlinks)

## Rechtliche Grundlage
TMG §5, UWG §5a — Affiliate-Links müssen in Deutschland deutlich gekennzeichnet werden.

## Test plan
- [ ] Produktseite aufrufen — Sternchen (*) beim Hero-CTA sichtbar
- [ ] Produktseite aufrufen — Sternchen (*) beim Sidebar-CTA sichtbar
- [ ] Sidebar-Disclosure-Text unter dem CTA lesbar
- [ ] Impressum prüfen — Affiliate-Hinweis-Abschnitt vorhanden
- [ ] Mobile-Ansicht prüfen — Hinweise nicht abgeschnitten

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Aktualisierungen**
  * Amazon Call-to-Action-Texte wurden mit Asterisken gekennzeichnet.
  * Ein Haftungsausschluss wurde hinzugefügt, der darauf hinweist, dass es sich um einen Affiliate-Link handelt und dem Nutzer keine zusätzlichen Kosten entstehen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->