### PR TITLE
fix(newsletter): address Brevo review findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Brevo Newsletter Configuration (DSGVO-konform, EU-basiert)
 # Get your API key from: https://app.brevo.com/settings/keys/api
 BREVO_API_KEY=your_brevo_api_key_here
+# Brevo contact list ID (default: 2)
+BREVO_LIST_ID=2
 
 # Site URL (used for sitemap generation)
 SITE_URL=https://zeitloseprodukte.de

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Brevo Newsletter Configuration (DSGVO-konform, EU-basiert)
 # Get your API key from: https://app.brevo.com/settings/keys/api
 BREVO_API_KEY=your_brevo_api_key_here
-# Brevo contact list ID (default: 2)
+# Brevo newsletter list ID (positive integer, default: 2)
 BREVO_LIST_ID=2
 
 # Site URL (used for sitemap generation)

--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -22,7 +22,9 @@ interface BrevoErrorResponse {
   message?: string
 }
 
-// Rate limiting: Simple in-memory store (for production, use Redis)
+// NOTE: In-memory rate limiting does not persist across Vercel Serverless invocations.
+// For production rate limiting, use Vercel WAF, Upstash Redis, or Brevo-side limits.
+// This provides basic protection during development and single-instance deployments.
 const rateLimitMap = new Map<string, { count: number; resetTime: number }>()
 const RATE_LIMIT_MAX = 5
 const RATE_LIMIT_WINDOW = 60 * 1000 // 1 minute
@@ -84,9 +86,10 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Check for required environment variables using env config
-    if (!env.brevo.isConfigured) {
-      console.error('Missing Brevo environment variables')
+    // Check for required Brevo API key
+    const apiKey = env.brevo.apiKey
+    if (!apiKey) {
+      console.error('Missing Brevo API key')
 
       // In development, log and return success
       if (env.isDevelopment) {
@@ -105,20 +108,18 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const { apiKey } = env.brevo
-
     // Subscribe via Brevo Contacts API
     const brevoResponse = await fetch(
       'https://api.brevo.com/v3/contacts',
       {
         method: 'POST',
         headers: {
-          'api-key': apiKey!,
+          'api-key': apiKey,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
           email: normalizedEmail,
-          listIds: [2],
+          listIds: [env.brevo.listId],
           updateEnabled: true,
         }),
       }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -59,8 +59,9 @@ export const env = {
       return getEnvVar('BREVO_API_KEY')
     },
     get listId() {
-      const id = getEnvVar('BREVO_LIST_ID')
-      return id ? parseInt(id, 10) : 2
+      const raw = getEnvVar('BREVO_LIST_ID')?.trim()
+      const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN
+      return Number.isInteger(parsed) && parsed > 0 ? parsed : 2
     },
     get isConfigured() {
       return Boolean(getEnvVar('BREVO_API_KEY'))

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -58,6 +58,10 @@ export const env = {
       warnMissingBrevo()
       return getEnvVar('BREVO_API_KEY')
     },
+    get listId() {
+      const id = getEnvVar('BREVO_LIST_ID')
+      return id ? parseInt(id, 10) : 2
+    },
     get isConfigured() {
       return Boolean(getEnvVar('BREVO_API_KEY'))
     },


### PR DESCRIPTION
## Summary
- Remove non-null assertion `apiKey!` by assigning apiKey once safely before use
- Document in-memory rate limiting as ineffective on Vercel Serverless (each invocation has own state)
- Make `listIds` configurable via `BREVO_LIST_ID` env variable (default: 2)

Closes #17

## Test plan
- [x] All 15 existing tests pass (`npm run test:run`)
- [ ] Verify newsletter signup works in dev mode without API key
- [ ] Verify `BREVO_LIST_ID` env var is picked up when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Die Brevo-Kontaktliste für Newsletter-Anmeldungen ist nun per Umgebungsvariable BREVO_LIST_ID konfigurierbar, mit Fallback auf 2.

* **Chores**
  * BREVO_LIST_ID in .env.example dokumentiert; Newsletter-Integration verwendet die konfigurierbare Listen-ID statt eines hartkodierten Werts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->