### PR TITLE
feat(affiliate): add /go/[slug] link cloaking with domain allowlist

### DIFF
--- a/app/go/[slug]/route.ts
+++ b/app/go/[slug]/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { products } from '@/lib/products'
+
+// Allowed redirect domains for security
+const ALLOWED_DOMAINS = ['www.amazon.de', 'amazon.de', 'amzn.to']
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params
+  const product = products.find((p) => p.slug === slug)
+
+  if (!product || !product.affiliateUrl) {
+    return NextResponse.redirect(new URL('/', request.url), 302)
+  }
+
+  const url = new URL(product.affiliateUrl)
+
+  // Security: Only redirect to allowed domains
+  if (!ALLOWED_DOMAINS.includes(url.hostname)) {
+    console.error(`Blocked redirect to unauthorized domain: ${url.hostname}`)
+    return NextResponse.redirect(new URL('/', request.url), 302)
+  }
+
+  url.searchParams.set('utm_source', 'zeitlosguteprodukte.de')
+  url.searchParams.set('utm_medium', 'affiliate')
+  url.searchParams.set('utm_campaign', slug)
+
+  return NextResponse.redirect(url.toString(), 302)
+}

--- a/app/go/[slug]/route.ts
+++ b/app/go/[slug]/route.ts
@@ -9,11 +9,11 @@ export async function GET(
   { params }: { params: Promise<{ slug: string }> }
 ) {
   const { slug } = await params
-  const product = products.find((p) => p.slug === slug)
-
-  if (!product || !product.affiliateUrl) {
+  const matches = products.filter((p) => p.slug === slug && p.affiliateUrl)
+  if (matches.length !== 1) {
     return new NextResponse('Not Found', { status: 404 })
   }
+  const product = matches[0]
 
   let url: URL
   try {
@@ -24,7 +24,7 @@ export async function GET(
 
   // Security: Only redirect to allowed HTTPS domains on standard port
   if (url.protocol !== 'https:' || !ALLOWED_DOMAINS.includes(url.hostname) || (url.port && url.port !== '443')) {
-    console.error(`Blocked redirect to unauthorized URL: ${url.toString()}`)
+    console.error(`Blocked redirect: host=${url.hostname} protocol=${url.protocol} port=${url.port || 'default'}`)
     return new NextResponse('Not Found', { status: 404 })
   }
 

--- a/app/go/[slug]/route.ts
+++ b/app/go/[slug]/route.ts
@@ -22,9 +22,9 @@ export async function GET(
     return new NextResponse('Not Found', { status: 404 })
   }
 
-  // Security: Only redirect to allowed domains
-  if (!ALLOWED_DOMAINS.includes(url.hostname)) {
-    console.error(`Blocked redirect to unauthorized domain: ${url.hostname}`)
+  // Security: Only redirect to allowed HTTPS domains on standard port
+  if (url.protocol !== 'https:' || !ALLOWED_DOMAINS.includes(url.hostname) || (url.port && url.port !== '443')) {
+    console.error(`Blocked redirect to unauthorized URL: ${url.toString()}`)
     return new NextResponse('Not Found', { status: 404 })
   }
 

--- a/app/go/[slug]/route.ts
+++ b/app/go/[slug]/route.ts
@@ -12,15 +12,20 @@ export async function GET(
   const product = products.find((p) => p.slug === slug)
 
   if (!product || !product.affiliateUrl) {
-    return NextResponse.redirect(new URL('/', request.url), 302)
+    return new NextResponse('Not Found', { status: 404 })
   }
 
-  const url = new URL(product.affiliateUrl)
+  let url: URL
+  try {
+    url = new URL(product.affiliateUrl)
+  } catch {
+    return new NextResponse('Not Found', { status: 404 })
+  }
 
   // Security: Only redirect to allowed domains
   if (!ALLOWED_DOMAINS.includes(url.hostname)) {
     console.error(`Blocked redirect to unauthorized domain: ${url.hostname}`)
-    return NextResponse.redirect(new URL('/', request.url), 302)
+    return new NextResponse('Not Found', { status: 404 })
   }
 
   url.searchParams.set('utm_source', 'zeitlosguteprodukte.de')

--- a/app/produkte/[slug]/page.tsx
+++ b/app/produkte/[slug]/page.tsx
@@ -358,14 +358,17 @@ export default async function ProductPage({ params }: ProductPageProps) {
                       {product.price}
                     </p>
                     <AffiliateLink
-                      href={product.affiliateUrl}
+                      href={`/go/${product.slug}`}
                       productSlug={product.slug}
                       productName={product.name}
                       variant="button"
                       className="w-full justify-center bg-cognac-600 hover:bg-cognac-500"
                     >
-                      Bei Amazon kaufen
+                      Bei Amazon kaufen*
                     </AffiliateLink>
+                    <p className="text-xs text-creme-100/60 mt-3">
+                      * Affiliate-Link — wir erhalten eine kleine Provision, für Sie entstehen keine Mehrkosten.
+                    </p>
                   </div>
                 </div>
               </aside>

--- a/app/produkte/[slug]/page.tsx
+++ b/app/produkte/[slug]/page.tsx
@@ -357,6 +357,7 @@ export default async function ProductPage({ params }: ProductPageProps) {
                     <p className="font-serif text-xl text-white mb-4">
                       {product.price}
                     </p>
+                    <AffiliateDisclosure className="text-xs text-creme-100/60 mb-3" />
                     <AffiliateLink
                       href={`/go/${product.slug}`}
                       productSlug={product.slug}
@@ -364,11 +365,8 @@ export default async function ProductPage({ params }: ProductPageProps) {
                       variant="button"
                       className="w-full justify-center bg-cognac-600 hover:bg-cognac-500"
                     >
-                      Bei Amazon kaufen*
+                      Bei Amazon kaufen
                     </AffiliateLink>
-                    <p className="text-xs text-creme-100/60 mt-3">
-                      * Affiliate-Link — wir erhalten eine kleine Provision, für Sie entstehen keine Mehrkosten.
-                    </p>
                   </div>
                 </div>
               </aside>

--- a/components/AffiliateLink.tsx
+++ b/components/AffiliateLink.tsx
@@ -26,9 +26,9 @@ declare global {
  * Affiliate Link Component with UTM tracking
  *
  * Adds UTM parameters to track affiliate link clicks:
- * - utm_source: zeitloseprodukte
+ * - utm_source: zeitlosguteprodukte.de
  * - utm_medium: affiliate
- * - utm_campaign: product-{slug}
+ * - utm_campaign: {slug}
  * - utm_content: {variant}
  */
 export default function AffiliateLink({
@@ -42,9 +42,9 @@ export default function AffiliateLink({
 }: AffiliateLinkProps) {
   // Build UTM parameters
   const utmParams = new URLSearchParams({
-    utm_source: 'zeitlosguteprodukte',
+    utm_source: 'zeitlosguteprodukte.de',
     utm_medium: 'affiliate',
-    utm_campaign: campaign || `product-${productSlug}`,
+    utm_campaign: campaign || productSlug,
     utm_content: variant,
   })
 

--- a/components/AffiliateLink.tsx
+++ b/components/AffiliateLink.tsx
@@ -48,8 +48,9 @@ export default function AffiliateLink({
     utm_content: variant,
   })
 
-  // Append UTM to URL
-  const trackedUrl = `${href}${href.includes('?') ? '&' : '?'}${utmParams.toString()}`
+  // Skip client-side UTM for /go/ links (UTM is added server-side in the route handler)
+  const isGoLink = href.startsWith('/go/')
+  const trackedUrl = isGoLink ? href : `${href}${href.includes('?') ? '&' : '?'}${utmParams.toString()}`
 
   // Track click event with Plausible Analytics
   const handleClick = () => {

--- a/components/AffiliateLink.tsx
+++ b/components/AffiliateLink.tsx
@@ -49,7 +49,7 @@ export default function AffiliateLink({
   })
 
   // Skip client-side UTM for /go/ links (UTM is added server-side in the route handler)
-  const isGoLink = href.startsWith('/go/')
+  const isGoLink = href.startsWith('/go/') || new URL(href, 'https://zeitlosguteprodukte.de').pathname.startsWith('/go/')
   const trackedUrl = isGoLink ? href : `${href}${href.includes('?') ? '&' : '?'}${utmParams.toString()}`
 
   // Track click event with Plausible Analytics


### PR DESCRIPTION
## Summary
- **Neuer Route Handler** `/go/[slug]` für sauberes Affiliate Link-Cloaking mit serverseitigen UTM-Parametern
- **Domain-Allowlist** (amazon.de, amzn.to) verhindert Open-Redirect-Angriffe
- **Sidebar** nutzt jetzt `/go/`-Links statt direkte `affiliateUrl` — konsistent mit Hero-Section
- **AffiliateLink-Komponente** überspringt client-seitige UTM-Generierung für `/go/`-Links (kein doppeltes Tracking)
- **Affiliate-Kennzeichnung** im Sidebar Buy-Card hinzugefügt (Sternchen + Hinweistext)

## Geänderte Dateien
- `app/go/[slug]/route.ts` — NEU: Redirect-Handler mit Allowlist
- `app/produkte/[slug]/page.tsx` — Sidebar auf `/go/`-Links + Disclosure
- `components/AffiliateLink.tsx` — UTM-Skip für `/go/`-Pfade

## Test plan
- [ ] `/go/le-creuset-braeter` redirected zu amazon.de mit UTM-Parametern
- [ ] `/go/nonexistent` redirected zur Startseite
- [ ] Sidebar-Button zeigt "Bei Amazon kaufen*" mit Affiliate-Hinweis
- [ ] Hero-Section nutzt weiterhin `/go/`-Links korrekt
- [ ] Keine doppelten UTM-Parameter in der finalen URL

Closes #8
Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Serverseitige slug-basierte Weiterleitungen für Affiliate-Links ergänzt.
  * Sichtbarer Affiliate-Hinweis in der Seitenleiste bei Produktseiten hinzugefügt.

* **Verbesserungen**
  * Affiliate-Links erhalten standardisierte UTM-Tracking-Parameter; Links, die über die interne /go/-Weiterleitung laufen, werden clientseitig nicht mehr verändert.
  * UTM-Quelle auf "zeitlosguteprodukte.de" angepasst; Kampagnenkennzeichnung vereinheitlicht.
  * Ziel-URLs werden auf Protokoll, erlaubte Domains und Port geprüft; nicht erlaubte Ziele werden geblockt und protokolliert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->